### PR TITLE
Example mail adress placeholder

### DIFF
--- a/locales/de-CH.json
+++ b/locales/de-CH.json
@@ -24,5 +24,6 @@
   "This content is for subscribers only": "Dieser Inhalt ist nur mit Abo sichtbar",
   "This content is for subscribers on the following tiers only:": "Dieser Inhalt ist nur für folgende Mitgliedschafts-Stufen sichtbar:",
   "Upgrade your account": "Mitgliedschafts-Stufe anpassen",
-  "Already member?": "Bereits Mitglied?"
+  "Already member?": "Bereits Mitglied?",
+  "jamie@example.com": "hans.muster@beispiel.com"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -24,6 +24,6 @@
   "This content is for subscribers only": "Dieser Inhalt ist nur mit Abo sichtbar",
   "This content is for subscribers on the following tiers only:": "Dieser Inhalt ist nur für folgende Mitgliedschafts-Stufen sichtbar:",
   "Upgrade your account": "Mitgliedschafts-Stufe anpassen",
-  "Already member?": "Bereits Mitglied?"
-
+  "Already member?": "Bereits Mitglied?",
+  "jamie@example.com": "max.mustermann@beispiel.com"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "This content is for paying subscribers only",
   "This content is for subscribers only": "This content is for subscribers only",
   "Upgrade your account": "Upgrade your account",
-  "Already member?": "Already member?"
+  "Already member?": "Already member?",
+  "jamie@example.com": "jamie@example.com"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "Ce contenu est réservé aux abonnés payants",
   "This content is for subscribers only": "This content is for subscribers only",
   "Upgrade your account": "Mettez votre compte à niveau",
-  "Already member?": "Déja membre?"
+  "Already member?": "Déja membre?",
+  "jamie@example.com": "jean.martin@exemple.com"
 }

--- a/locales/ga.json
+++ b/locales/ga.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "Tá suibscríbhinn íoctha ag teastáil chun an t-ábhar seo a fheiceáil",
   "This content is for subscribers only": "Tá suibscríbhinn ag teastáil chun an t-ábhar seo a fheiceáil",
   "Upgrade your account": "Uasghrádaigh leibhéal do chuntais",
-  "Already member?": "An bhfuil tú cláraithe cheana féin?"
+  "Already member?": "An bhfuil tú cláraithe cheana féin?",
+  "jamie@example.com": "sean.oceallaigh@sampla.com"
 }

--- a/locales/gd.json
+++ b/locales/gd.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "Feumar fò-sgrìobhadh paighte airson an t-susbaint seo fhaicinn",
   "This content is for subscribers only": "Feumar fò-sgrìobhadh airson an t-susbaint seo fhaicinn",
   "Upgrade your account": "Àrdaich ìre a' chunntais agad",
-  "Already member?": "A bheil thu nad bhall mar thà?"
+  "Already member?": "A bheil thu nad bhall mar thà?",
+  "jamie@example.com": "alasdair.macdonald@eisimpleir.com"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "Deze pagina is alleen voor betalende leden zichtbaar",
   "This content is for subscribers only": "Deze pagina is alleen voor leden zichtbaar",
   "Upgrade your account": "Account upgraden",
-  "Already member?": "Al lid?"
+  "Already member?": "Al lid?",
+  "jamie@example.com": "jan.jansen@voorbeeld.com"
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "Este conteúdo é exclusivo para assinantes",
   "This content is for subscribers only": "Este conteúdo é apenas para inscritos",
   "Upgrade your account": "Atualize sua conta",
-  "Already member?": "Já é inscrito?"
+  "Already member?": "Já é inscrito?",
+  "jamie@example.com": "joao.silva@exemplo.com"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -23,6 +23,7 @@
     "This content is for paying subscribers only": "Det här innehållet är endast för betalande medlemmar",
     "This content is for subscribers only": "Det här innehållet är endast för medlemmar",
     "Upgrade your account": "Uppgradera ditt konto",
-    "Already member?": "Redan medlem?"
+    "Already member?": "Redan medlem?",
+    "jamie@example.com": "karl.johansson@exempel.com"
   }
   

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "Цей контент доступний лише для платних підписників",
   "This content is for subscribers only": "Цей контент доступний лише для підписників",
   "Upgrade your account": "Покращити свій обліковий запис",
-  "Already member?": "Вже є учасником?"
+  "Already member?": "Вже є учасником?",
+  "jamie@example.com": "ivan.koval@приклад.com"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "此内容仅供付费订阅用户使用",
   "This content is for subscribers only": "此内容仅供订阅用户使用",
   "Upgrade your account": "升级你的账户",
-  "Already member?": "已经是会员了？"
+  "Already member?": "已经是会员了？",
+  "jamie@example.com": "张伟@示例.com"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -23,5 +23,6 @@
   "This content is for paying subscribers only": "此内容仅供付费订阅用户使用",
   "This content is for subscribers only": "此内容仅供订阅用户使用",
   "Upgrade your account": "升级你的账户",
-  "Already member?": "已经是会员了？"
+  "Already member?": "已经是会员了？",
+  "jamie@example.com": "張偉@範例.com"
 }

--- a/partials/email-subscription.hbs
+++ b/partials/email-subscription.hbs
@@ -1,5 +1,5 @@
 <form class="gh-form" data-members-form>
-    <input class="gh-form-input" id="{{email_field_id}}" name="email" type="email" placeholder="jamie@example.com" required data-members-email>
+    <input class="gh-form-input" id="{{email_field_id}}" name="email" type="email" placeholder="{{t jamie@example.com}}" required data-members-email>
     <button class="gh-button" type="submit" aria-label="Subscribe">
         <span><span>{{t "Subscribe"}}</span> {{> "icons/arrow"}}</span>
         {{> "icons/loader"}}


### PR DESCRIPTION
I think the CTA placeholder needs translating. It was the only visible thing in my theme that sounded "American".