### PR TITLE
Public preview fade out effect

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -2262,6 +2262,20 @@ unless a heading is the very first element in the post content */
     font-family: var(--font-mono);
 }
 
+/* Public Preview Fading Effect for Last Paragraph */
+.fadeout-content p:last-child {
+    -webkit-mask-image: linear-gradient(to bottom, var(--color-black) 1%, transparent 100%);
+    mask-image: linear-gradient(to bottom, var(--color-black) 1%, transparent 100%);
+    margin-bottom: 1.5em; /* Ensure consistent spacing */
+}
+
+/* Reset other paragraphs to prevent unintended effects */
+.fadeout-content p:not(:last-child) {
+    -webkit-mask-image: none;
+    mask-image: none;
+    margin-bottom: 1.5em; /* Ensure normal paragraph spacing */
+}
+
 /* 16. Cards
 /* ---------------------------------------------------------- */
 

--- a/partials/content-cta.hbs
+++ b/partials/content-cta.hbs
@@ -1,4 +1,9 @@
 {{{html}}}
+<div class="fadeout">
+    <div class="fadeout-content">
+        {{{html}}}
+    </div>
+</div>
 <aside class="gh-post-upgrade-cta">
     <div class="gh-post-upgrade-cta-content" style="background-color: {{@site.accent_color}}">
         {{#has visibility="paid"}}


### PR DESCRIPTION
I think this is an essential feature for any Ghost theme.

Without it, it's difficult for the reader to project the fact that the article has a sequel.
https://forum.ghost.org/t/public-preview-fade-out-effect-removes-spaces-between-paragraphs/49867/3

I've based myself on this forum thread and it's a code I've tested locally that works well.